### PR TITLE
Bump SDK version, disable linting for translations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,10 +9,10 @@ android {
 
     defaultConfig {
         applicationId = "net.bitplane.android.microphone"
-        minSdk = 19
+        minSdk = 21
         targetSdk = 34
-        versionCode = 7
-        versionName = "0.7"
+        versionCode = 8
+        versionName = "0.8"
     }
 
     buildTypes {
@@ -31,6 +31,8 @@ android {
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
+    lint.disable += "MissingTranslation"
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.bitplane.android.microphone">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
@@ -39,3 +38,4 @@
 
     </application>
 </manifest>
+


### PR DESCRIPTION
I was unable to compile the APK locally due to
 - errors with missing translations,
 - errors with the minimum SDK level being too low,
 - (additional warnings about `package` being deprecated in `AndroidManifest`),  

which are all fixed in this PR.

I also bumped the version number to reflect these changes. Please update the app on F-Droid too, as the version currently published there is not installable on modern android devices (tested on android 14).

